### PR TITLE
Update vite.config.ts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,16 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-// https://vitejs.dev/config/
 export default defineConfig({
-	plugins: [react()],
+  plugins: [react()],
+  server: {
+    host: true, // Permite acesso externo
+    allowedHosts: [
+      'hamper.duckdns.org', // Domínio DuckDNS
+      'localhost', // Acesso local
+      '0.0.0.0',   // Permite qualquer IP (cuidado em produção)
+      '100.26.203.78' // Substitua pelo seu IP real
+    ],
+    cors: true // Habilita CORS
+  }
 });


### PR DESCRIPTION
Adicionando hosts permitidos para usarmos o DNS da duck, localhost e o ip atual da aws.